### PR TITLE
Correct test imports to actually use FUN-GLL

### DIFF
--- a/src/GLL/Combinators/Test/Expr.hs
+++ b/src/GLL/Combinators/Test/Expr.hs
@@ -3,7 +3,7 @@ module Main where
 
 import Control.Monad
 import qualified GLL.Combinators.MemInterface as Mem
-import GLL.Combinators.Interface
+import GLL.ParserCombinators
 
 -- | Datatype representing arithmetic expressions
 data Expr   = Add Expr Expr

--- a/src/GLL/Combinators/Test/Interface.hs
+++ b/src/GLL/Combinators/Test/Interface.hs
@@ -33,7 +33,7 @@ import Data.Char (ord)
 import Data.List (sort, nub)
 import Data.IORef
 
-import GLL.Combinators.Interface
+import GLL.ParserCombinators
 import GLL.Parseable.Char ()
 
 -- | Defines and executes multiple1 unit-tests 


### PR DESCRIPTION
Currently the tests import the `GLL.Combinators.Interface` module which is exposed by the old package, `gll`. Changing this to `GLL.ParserCombinators` causes the FUN-GLL combinators to be used instead.

Fortunately all the tests pass with the FUN-GLL combinators, but it was a bit weird debugging my modifications that weren't actually being loaded.